### PR TITLE
Feature/email subscription bug fixing

### DIFF
--- a/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscribeHubSpotModel.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscribeHubSpotModel.cs
@@ -15,7 +15,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
         public string PortalSubscriptionLegalBasisExplanation { get; set; }
         
         [IgnoreDataMember]
-        [Obsolete]
+        [Obsolete( "This property is obsolete. Use PortalSubscriptionLegalBasis instead.",false)]
         public string SubscriptionLegalBasis {
             get
             {
@@ -28,7 +28,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
         }
 
         [IgnoreDataMember]
-        [Obsolete]
+        [Obsolete( "This property is obsolete. Use PortalSubscriptionLegalBasisExplanation instead.",false)]
         public string SubscriptionLegalBasisExplanation {
             get
             {

--- a/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscribeHubSpotModel.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscribeHubSpotModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using HubSpot.NET.Core.Interfaces;
 
@@ -6,17 +7,44 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
 {
     public class SubscribeHubSpotModel : IHubSpotModel
     {
+        
         [DataMember(Name = "portalSubscriptionLegalBasis")]
-        public string SubscriptionLegalBasis { get;set; }
+        public string PortalSubscriptionLegalBasis { get;set; }
 
         [DataMember(Name = "portalSubscriptionLegalBasisExplanation")]
-        public string SubscriptionLegalBasisExplanation { get; set; }
+        public string PortalSubscriptionLegalBasisExplanation { get; set; }
+        
+        [IgnoreDataMember]
+        [Obsolete]
+        public string SubscriptionLegalBasis {
+            get
+            {
+                return PortalSubscriptionLegalBasis;
+            }
+            set
+            {
+                PortalSubscriptionLegalBasis = value;
+            }
+        }
+
+        [IgnoreDataMember]
+        [Obsolete]
+        public string SubscriptionLegalBasisExplanation {
+            get
+            {
+                return PortalSubscriptionLegalBasisExplanation;
+            }
+            set
+            {
+                PortalSubscriptionLegalBasisExplanation = value;
+            }
+        }
 
         [DataMember(Name = "subscriptionStatuses")]
         public List<SubscribeStatusHubSpotModel> SubscriptionStatuses { get; set; }
 
         [IgnoreDataMember]
-        public bool IsNameValue { get; }
+        public bool IsNameValue => true;
 
         public void ToHubSpotDataEntity(ref dynamic dataEntity)
         {

--- a/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscribeHubSpotModel.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscribeHubSpotModel.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.EmailSubscriptions.Dto
@@ -19,6 +15,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
         [DataMember(Name = "subscriptionStatuses")]
         public List<SubscribeStatusHubSpotModel> SubscriptionStatuses { get; set; }
 
+        [IgnoreDataMember]
         public bool IsNameValue { get; }
 
         public void ToHubSpotDataEntity(ref dynamic dataEntity)
@@ -29,6 +26,8 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
         {
         }
 
+        [IgnoreDataMember]
         public string RouteBasePath => "/email/public/v1/subscriptions";
     }
+
 }

--- a/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscriptionStatusDetailHubSpotModel.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscriptionStatusDetailHubSpotModel.cs
@@ -12,5 +12,14 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
 
         [DataMember(Name = "updatedAt")]
         public string UpdatedAt { get;set; }
+        
+        [DataMember(Name = "optState")]
+        public string OptState { get; set; }
+        
+        [DataMember(Name = "legalBasis")]
+        public string LegalBasis { get; set; }
+
+        [DataMember(Name = "legalBasisExplanation")]
+        public string LegalBasisExplanation { get; set; }
     }
 }

--- a/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscriptionStatusHubSpotModel.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscriptionStatusHubSpotModel.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 using HubSpot.NET.Core.Interfaces;
 
 namespace HubSpot.NET.Api.EmailSubscriptions.Dto
@@ -14,13 +10,13 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
         public bool Subscribed { get; set; }
 
         [DataMember(Name = "markedAsSpam")]
-        public bool MarkedAsSpam { get;set; }
+        public bool MarkedAsSpam { get; set; }
 
         [DataMember(Name = "bounced")]
         public bool Bounced { get; set; }
 
         [DataMember(Name = "email")]
-        public string Email { get;set; }
+        public string Email { get; set; }
 
         [DataMember(Name = "status")]
         public string Status { get; set; }
@@ -28,6 +24,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
         [DataMember(Name = "subscriptionStatuses")]
         public List<SubscriptionStatusDetailHubSpotModel> SubscriptionStatuses { get; set; }
 
+        [IgnoreDataMember]
         public bool IsNameValue { get; }
 
         public void ToHubSpotDataEntity(ref dynamic dataEntity)
@@ -38,6 +35,7 @@ namespace HubSpot.NET.Api.EmailSubscriptions.Dto
         {
         }
 
+        [IgnoreDataMember]
         public string RouteBasePath => "/email/public/v1";
     }
 }

--- a/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscriptionStatusUpdateHubSpotModel.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/Dto/SubscriptionStatusUpdateHubSpotModel.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using HubSpot.NET.Core.Interfaces;
+
+namespace HubSpot.NET.Api.EmailSubscriptions.Dto
+{
+    /// <summary>
+    /// The subscription status update hub spot model class
+    /// </summary>
+    /// <seealso cref="IHubSpotModel"/>
+    public class SubscriptionStatusUpdateHubSpotModel : IHubSpotModel
+    {
+        /// <summary>
+        /// Gets or sets the value of the subscription statuses
+        /// </summary>
+        [DataMember(Name = "subscriptionStatuses")]
+        public List<SubscriptionStatusDetailHubSpotModel> SubscriptionStatuses { get; set; }
+
+        /// <summary>
+        /// Gets the value of the is name value
+        /// </summary>
+        [IgnoreDataMember]
+        public bool IsNameValue { get; }
+
+        /// <summary>
+        /// Returns the hub spot data entity using the specified data entity
+        /// </summary>
+        /// <param name="dataEntity">The data entity</param>
+        public void ToHubSpotDataEntity(ref dynamic dataEntity)
+        {
+        }
+
+        /// <summary>
+        /// Creates the hub spot data entity using the specified hubspot data
+        /// </summary>
+        /// <param name="hubspotData">The hubspot data</param>
+        public void FromHubSpotDataEntity(dynamic hubspotData)
+        {
+        }
+
+        /// <summary>
+        /// Gets the value of the route base path
+        /// </summary>
+        [IgnoreDataMember]
+        public string RouteBasePath => "/email/public/v1";
+    }
+}

--- a/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
@@ -1,14 +1,25 @@
-﻿namespace HubSpot.NET.Api.EmailSubscriptions
+namespace HubSpot.NET.Api.EmailSubscriptions
 {
     using System.Collections.Generic;
     using HubSpot.NET.Api.EmailSubscriptions.Dto;
     using HubSpot.NET.Core.Interfaces;
     using RestSharp;
 
+    /// <summary>
+    /// The hub spot email subscriptions api class
+    /// </summary>
+    /// <seealso cref="IHubSpotEmailSubscriptionsApi"/>
     public class HubSpotEmailSubscriptionsApi : IHubSpotEmailSubscriptionsApi
     {
+        /// <summary>
+        /// The client
+        /// </summary>
         private readonly IHubSpotClient _client;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HubSpotEmailSubscriptionsApi"/> class
+        /// </summary>
+        /// <param name="client">The client</param>
         public HubSpotEmailSubscriptionsApi(IHubSpotClient client)
         {
             _client = client;
@@ -58,7 +69,7 @@
         {
             var path = $"{new SubscriptionTypeListHubSpotModel().RouteBasePath}/subscriptions/{email}";
 
-            var model = new SubscriptionStatusHubSpotModel
+            var model = new SubscriptionStatusUpdateHubSpotModel
             {
                 SubscriptionStatuses = new List<SubscriptionStatusDetailHubSpotModel>()
                 {
@@ -74,26 +85,51 @@
         }
 
 
+
         /// <summary>
         /// Subscribe the given email address to the given subscription type
         /// See <see cref="https://legacydocs.hubspot.com/docs/methods/email/update_status"/>
-        /// </summary>
-        public void SubscribeTo(string email, long id, string basis, string basisExplaination)
+        /// </summary>        /// <param name="email">The email</param>
+        /// <param name="id">The id</param>
+        /// <param name="basis">The basis</param>
+        /// <param name="basisExplanation">The basis explanation</param>
+        /// <param name="setPortalSubscriptionBasis">The set portal subscription basis</param>
+        /// <param name="setSubscriptionBasis">The set subscription basis</param>
+        /// <param name="subscriptionBasis">The subscription basis</param>
+        /// <param name="subscriptionBasisExplanation">The subscription basis explanation</param>
+        public void SubscribeTo(string email, long id, string basis, string basisExplanation, bool setPortalSubscriptionBasis = true, bool setSubscriptionBasis = false, string subscriptionBasis = null, string subscriptionBasisExplanation = null)
         {
+            var subscription = new SubscribeStatusHubSpotModel()
+            {
+                Id = id,
+                Subscribed = true,
+                OptState = "OPT_IN"
+            };
+            if (setSubscriptionBasis)
+            {
+                if (string.IsNullOrEmpty(subscriptionBasis))
+                {
+                    subscriptionBasis = basis;
+                }
+
+                if (subscriptionBasisExplanation == null)
+                {
+                    subscriptionBasisExplanation = basisExplanation;
+                }
+
+                subscription.LegalBasis = subscriptionBasis;
+                subscription.LegalBasisExplanation = subscriptionBasisExplanation;
+            }
+
             var model = new SubscribeHubSpotModel
             {
-                SubscriptionStatuses = new List<SubscribeStatusHubSpotModel>()
-                {
-                    new SubscribeStatusHubSpotModel()
-                    {
-                        Id = id,
-                        Subscribed = true,
-                        OptState = "OPT_IN"
-                    }
-                },
-                SubscriptionLegalBasis = basis,
-                SubscriptionLegalBasisExplanation = basisExplaination
+                SubscriptionStatuses = new List<SubscribeStatusHubSpotModel>() { subscription }
             };
+            if (setPortalSubscriptionBasis)
+            {
+                model.SubscriptionLegalBasis = basis;
+                model.SubscriptionLegalBasisExplanation = basisExplanation;
+            }
 
             var path = $"{model.RouteBasePath}/{email}";
 

--- a/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
+++ b/HubSpot.NET/Api/EmailSubscriptions/HubSpotEmailSubcriptionsApi.cs
@@ -127,8 +127,8 @@ namespace HubSpot.NET.Api.EmailSubscriptions
             };
             if (setPortalSubscriptionBasis)
             {
-                model.SubscriptionLegalBasis = basis;
-                model.SubscriptionLegalBasisExplanation = basisExplanation;
+                model.PortalSubscriptionLegalBasis = basis;
+                model.PortalSubscriptionLegalBasisExplanation = basisExplanation;
             }
 
             var path = $"{model.RouteBasePath}/{email}";

--- a/HubSpot.NET/Core/Interfaces/IHubSpotEmailSubscriptionsApi.cs
+++ b/HubSpot.NET/Core/Interfaces/IHubSpotEmailSubscriptionsApi.cs
@@ -30,7 +30,14 @@ namespace HubSpot.NET.Core.Interfaces
         /// <summary>
         /// Subscribe the given email address to the given subscription type
         /// See <see cref="https://legacydocs.hubspot.com/docs/methods/email/update_status"/>
-        /// </summary>
-        void SubscribeTo(string email, long id, string basis, string basisExplaination);
+        /// </summary>        /// <param name="email">The email</param>
+        /// <param name="id">The id</param>
+        /// <param name="basis">The basis</param>
+        /// <param name="basisExplanation">The basis explanation</param>
+        /// <param name="setPortalSubscriptionBasis">The set portal subscription basis</param>
+        /// <param name="setSubscriptionBasis">The set subscription basis</param>
+        /// <param name="subscriptionBasis">The subscription basis</param>
+        /// <param name="subscriptionBasisExplanation">The subscription basis explanation</param>
+        void SubscribeTo(string email, long id, string basis, string basisExplanation, bool setPortalSubscriptionBasis = true, bool setSubscriptionBasis = false, string subscriptionBasis = null, string subscriptionBasisExplanation = null);
     }
 }


### PR DESCRIPTION
## Description
Upon testing I found a number issues with email subscriptions.  This PR hopes to address the following issues;

## Purpose
- [ ] Bugfix - Portal legal basis was not serialised correctly in some frameworks resulting in portal basis not being set via the API
- [ ] New feature - You can now apply legal basis to an individual subscription as well at the portal level.  This is defined as optional parameters to avoid breaking changes.
- [ ] Bugfix - Corrected spelling mistake in SubscribeTo method parameters
- [ ] New feature - Return opt state, legal basis and legal basis explanation when getting email subscriptions for a contact
- [ ] Bugfix - UnsubscribeFrom was not removing subscriptions and was passing unneeded data in serialised API request
- [ ] New feature - SubscriptionLegalBasis and SubscriptionLegalBasisExplanation properties within SubscribeHubSpotModel have been marked as obsolete and new Portal* properties have been created to more closely match API specification and avoid confusion with subscription legal basis - This is a non breaking change.
